### PR TITLE
Make to_yaml_file consider options when writing to file path

### DIFF
--- a/src/pydantic_yaml/dumper.py
+++ b/src/pydantic_yaml/dumper.py
@@ -195,4 +195,14 @@ def to_yaml_file(
         raise TypeError(f"Expected Path, str, or stream, but got {file!r}")
 
     with file.open(mode="w") as f:
-        _write_yaml_model(f, model, **json_kwargs)
+        _write_yaml_model(
+            f,
+            model,
+            default_flow_style=default_flow_style,
+            indent=indent,
+            map_indent=map_indent,
+            sequence_indent=sequence_indent,
+            sequence_dash_offset=sequence_dash_offset,
+            custom_yaml_writer=custom_yaml_writer,
+            **json_kwargs
+        )


### PR DESCRIPTION
When passing a path to `to_yaml_file`, the output was different from `to_yaml_str`, although using the same options. The new options for `_write_yaml_model` had only been added to the first if branch, not to the second case.